### PR TITLE
Added support for nested queries on ObjectID

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,19 +161,159 @@ Please see the Winston documentation for more setup details: https://github.com/
 Supported REST API
 ------------------
 
-Supported REST API requests:
+**Listing Databases:**
+_Format:_ `GET /dbs`
 
-* `GET /dbs` - Returns the names of all databases.
-* `GET /<db>/` - Returns names of all collections in the specified database.
-* `GET /<db>/<collection>` - Returns all documents in the specified collection.
-* `GET /<db>/<collection>?output=csv` - Returns all documents in collection in csv format.
-* `GET /<db>/<collection>?query=%7B%22isDone%22%3A%20false%7D` - Returns all documents satisfying query.
-* `GET /<db>/<collection>?query=%7B%22isDone%22%3A%20false%7D&limit=2&skip=2` - Ability to add options to query (limit, skip, 
-etc)
-* `GET /<db>/<collection>/id` - Returns document with _id_
-* `POST /<db>/<collection>` - Insert new document in collection (document in POST body)
-* `PUT /<db>/<collection>/id` - Update document with _id_ (updated document in PUT body)
-* `DELETE /<db>/<collection>/id` - Delete document with _id_
+    $ curl 'http://127.0.0.1:3000/dbs/' \
+    >   -D - \
+    >   -H 'Accept: application/json'
+    HTTP/1.1 200 OK
+    X-Powered-By: Express
+    Content-Type: application/json; charset=utf-8
+    Content-Length: 27
+    ETag: W/"1b-134804454"
+    Date: Thu, 02 Jul 2015 08:02:26 GMT
+    Connection: keep-alive
+    
+    [
+        "local",
+        "test"
+    ]
+
+
+**Listing Collections:**
+_Format:_`GET /<db>/`
+
+
+    $ curl 'http://127.0.0.1:3000/test/' \
+    >   -D - \
+    >   -H 'Accept: application/json'
+    HTTP/1.1 200 OK
+    X-Powered-By: Express
+    Content-Type: application/json; charset=utf-8
+    Content-Length: 27
+    ETag: W/"1b-134804454"
+    Date: Thu, 02 Jul 2015 08:02:26 GMT
+    Connection: keep-alive
+    
+    [
+       "new-collection",
+       "startup_log",
+       "system.indexes"
+    ]
+
+
+**List Documents in a Collection:**
+_Format:_ `GET /<db>/<collection>`
+
+    $ curl 'http://127.0.0.1:3000/test/new-collection' \
+    >   -D - \
+    >   -H 'Accept: application/json'
+    HTTP/1.1 200 OK
+    X-Powered-By: Express
+    Content-Type: application/json; charset=utf-8
+    Content-Length: 27
+    ETag: W/"1b-134804454"
+    Date: Thu, 02 Jul 2015 08:02:26 GMT
+    Connection: keep-alive
+
+    [
+        {
+            "_id": "5594bf2b019d364a083f2e03",
+            "attribute": "hello"
+        }
+    ]
+
+**Output a CSV collection:**
+_Format:_`GET /<db>/<collection>?output=csv`
+
+    $ curl http://127.0.0.1:3000/test/newcollection?output=csv > Sample.csv
+
+**List documents satisfying a query:**
+_Format:_`GET /<db>/<collection>?query={"key":"value"}`
+    
+    $ curl -X "GET" http://localhost:3000/test/newcollection \
+    -d 'query={"attribute":"value"}
+    [
+    {
+        "_id": "5594bf2b019d364a083f2e03",
+        "attribute": "value"
+    }
+    ]
+
+
+**List documents with nested queries:**
+_Format:_`GET /<db>/<collection>?query={"key":{"second_key":{"_id":"value"}}}`
+
+    $ curl -X "GET" http://localhost:3000/test/newcollection \
+        -d 'query={"attribute":{"other_attribute:{"_id":"5063114bd386d8fadbd6b004"}}}
+        [
+        {
+            "_id": "5594bf2b019d364a083f2e03",
+            "attribute": {
+                other_attribute: "5063114bd386d8fadbd6b004"
+            }
+        }
+        ]
+        
+**Return document by id:**
+_Format_ `GET /<db>/<collection>/id`
+    
+    $ curl -X "GET" http://localhost:3000/test/nested/5594bf2b019d364a083f2e03
+    {
+        "_id": "5594bf2b019d364a083f2e03",
+        "attribute": "hello"
+    }
+    
+**Inserting documents:**
+_Format:_ `POST /<db>/<collection>`
+
+    $ curl 'http://localhost:3000/test/newcollection' \
+    >   -D - \
+    >   -X POST \
+    >   -H 'Content-Type: application/json' \
+    >   -H 'Accept: application/json' \
+    >   --data '{"title": "Some title", "content": "document content"}'
+    
+    HTTP/1.1 201 CREATED
+    Date: Thu, 02 Jul 2015 12:50:34 GMT
+    Connection: keep-alive
+    Content-Type: application/json; charset=utf-8
+    X-Powered-By: Express
+    Location: /test/nested/5595339aa73107ad070e891a
+    Content-Length: 15
+    {
+        "ok": 1
+    }
+    
+**Updating a document:**
+_Format_: `PUT /<db>/<collection>/id`
+
+    $ curl -X "PUT" "http://localhost:3000/test/nested/5595339aa73107ad070e891a \
+    > --data {"title": "New title", "content": "New document content"}'
+    HTTP/1.1 200 OK
+    Connection: keep-alive
+    Content-Type: application/json; charset=utf-8
+    X-Powered-By: Express
+    Content-Length: 15
+    Date: Thu, 02 Jul 2015 12:53:00 GMT
+    {
+        "ok": 1
+    }
+    
+**Deleting a document by id:**
+_Format:_ `DELETE /<db>/<collection>/id`
+
+    $ curl -X "DELETE" "http://localhost:3000/test/nested/5595339aa73107ad070e891a
+    HTTP/1.1 200 OK
+    Connection: keep-alive
+    Content-Type: application/json; charset=utf-8
+    X-Powered-By: Express
+    Content-Length: 15
+    Date: Thu, 02 Jul 2015 12:53:00 GMT
+    {
+        "ok": 1
+    }
 
 Content Type:
 

--- a/lib/rest.js
+++ b/lib/rest.js
@@ -204,19 +204,37 @@ module.exports = function (app, config) {
     */
     app.get(urlPrefix + '/:db/:collection/:id?', function(req, res) { 
         var query = req.query.query ? JSON.parse(req.query.query) : {};
+        var namings = ['_id', '$id', "$oid"];
+
         // Providing an id overwrites giving a query in the URL
         if (req.params.id) {
             query = {'_id': new BSON.ObjectID(req.params.id)};
-        } 
-        //Check if there is a nested query
-        else if (typeof(query[Object.keys(query)]) == 'object'){
-            if(typeof(query[Object.keys(query)]['_id']) !== undefined){
-                var nested = query[Object.keys(query)]['_id'];
-                var obj_id = new BSON.ObjectID.createFromHexString(nested);
+        }
 
-                //Reformat the query
-                query[Object.keys(query)] = obj_id;
-            }
+        //Check if there is a nested queries
+        else if (typeof(query[Object.keys(query)]) == 'object'){
+
+            //Parse down the object tree
+            (function searchObj( obj ){
+
+                for( var key in obj ) {
+
+                    //Found nested object - going deeper
+                    if( typeof obj[key] === 'object' ){
+                        obj[key] = searchObj( obj[key] );
+                    }
+
+                    //Found a match
+                    if( namings.indexOf(key) > -1 ){
+                        //Cast the id to an Object id
+                        return obj = new BSON.ObjectID.createFromHexString(obj[key]);
+                    } else {
+                        return obj
+                    }
+
+                }
+
+            })(query);
         }
 
         var options = req.params.options || {};
@@ -229,7 +247,7 @@ module.exports = function (app, config) {
                 if (needParse.indexOf(o) >= 0) {
                     options[o] = JSON.parse(req.query[o]);
                 } else {
-                    options[o] = req.query[o];  
+                    options[o] = req.query[o];
                 }
             } 
         }

--- a/lib/rest.js
+++ b/lib/rest.js
@@ -206,13 +206,23 @@ module.exports = function (app, config) {
         var query = req.query.query ? JSON.parse(req.query.query) : {};
         var namings = ['_id', '$id', "$oid"];
 
+        //Function to test whether object has nested objects
+        function testForNested(obj){
+            for (var i = 0; i < Object.keys(query).length; i++) {
+                if(typeof(obj[Object.keys(obj)[i]]) == 'object'){
+                    return true;
+                }
+            };
+            return false;    
+        }
+
         // Providing an id overwrites giving a query in the URL
         if (req.params.id) {
             query = {'_id': new BSON.ObjectID(req.params.id)};
         }
 
         //Check if there is a nested queries
-        else if (typeof(query[Object.keys(query)]) == 'object'){
+        else if (testForNested(query)){
 
             //Parse down the object tree
             (function searchObj( obj ){

--- a/lib/rest.js
+++ b/lib/rest.js
@@ -5,9 +5,10 @@
     Maintained by Ashley Davis 2014-07-02
     Created by Tom de Grunt on 2010-10-03.
     Copyright (c) 2010 Tom de Grunt.
-		This file is part of mongodb-rest.
+        This file is part of mongodb-rest.
 */ 
 var mongodb = require("mongodb");
+    ObjectID = require('mongodb').ObjectID;
 var connection = require('./connection');
 var auth = require('./auth');
 var BSON = mongodb.BSONPure;
@@ -203,11 +204,21 @@ module.exports = function (app, config) {
     */
     app.get(urlPrefix + '/:db/:collection/:id?', function(req, res) { 
         var query = req.query.query ? JSON.parse(req.query.query) : {};
-
         // Providing an id overwrites giving a query in the URL
         if (req.params.id) {
             query = {'_id': new BSON.ObjectID(req.params.id)};
+        } 
+        //Check if there is a nested query
+        else if (typeof(query[Object.keys(query)]) == 'object'){
+            if(typeof(query[Object.keys(query)]['_id']) !== undefined){
+                var nested = query[Object.keys(query)]['_id'];
+                var obj_id = new BSON.ObjectID.createFromHexString(nested);
+
+                //Reformat the query
+                query[Object.keys(query)] = obj_id;
+            }
         }
+
         var options = req.params.options || {};
 
         var test = ['limit','sort','fields','skip','hint','explain','snapshot','timeout'];
@@ -218,7 +229,7 @@ module.exports = function (app, config) {
                 if (needParse.indexOf(o) >= 0) {
                     options[o] = JSON.parse(req.query[o]);
                 } else {
-                    options[o] = req.query[o];
+                    options[o] = req.query[o];  
                 }
             } 
         }


### PR DESCRIPTION
This commit adds support for schemas where there are multiple attributes
of ObjectID type. Query syntax is similar to the Mora-Rest API:
    query = {"some_attribute" : {"_id" : "550c37ebbc2e8b6a1c0031cb"}}
The query will be preprocessed and the hex string will be extracted and casted
to ObjectID type before being sent to mongodb for searching.
